### PR TITLE
change to throw error if directory of dictionary file is invalid

### DIFF
--- a/dist/node/loader/DictionaryLoader.js
+++ b/dist/node/loader/DictionaryLoader.js
@@ -201,7 +201,10 @@ NodeDictionaryLoader.prototype = Object.create(DictionaryLoader.prototype);
  */
 NodeDictionaryLoader.prototype.loadArrayBuffer = function (file, callback) {
     fs.readFile(file, function (err, buffer) {
-        var gz = new zlib.Zlib.Gunzip(new Uint8Array(buffer));
+        if (err) {
+	    throw new Error(err);
+	}
+	var gz = new zlib.Zlib.Gunzip(new Uint8Array(buffer));
         var typed_array = gz.decompress();
         callback(null, typed_array.buffer);
     });


### PR DESCRIPTION
This update force program to throw error when the user give invalid parameter of dictionary files.
Now, the program executes endless loop when cannot open dictionary files.