### PR TITLE
Corrected typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Directory tree is as follows:
 Usage
 -----
 
-You can tokenize sentences by only 5 lines of code.
-If you need working examples, see also files under demo or example directory.
+You can tokenize sentences with only 5 lines of code.
+If you need working examples, you can see the files under the demo or example directory.
 
 
 ### Node.js
 
-Install by npm package manager:
+Install with npm package manager:
 
     npm install kuromoji
 
@@ -62,11 +62,11 @@ You can prepare tokenizer like this:
 
 You only need the dist/browser/kuromoji.js and dist/dict/*.dat.gz files
 
-Install by Bower package manager:
+Install with Bower package manager:
 
     bower install kuromoji
 
-Or you can use kuromoji.js file and dictionary files from GitHub repository.
+Or you can use the kuromoji.js file and dictionary files from the GitHub repository.
 
 In your HTML:
 
@@ -84,7 +84,7 @@ In your JavaScript:
 API
 ---
 
-The function tokenize() returns JSON array like this:
+The function tokenize() returns an JSON array like this:
 
     [ {
         word_id: 509800,          // 辞書内での単語ID
@@ -102,6 +102,6 @@ The function tokenize() returns JSON array like this:
         pronunciation: 'クロモジ'  // 発音
       } ]
 
-(This is defined by src/util/IpadicFormatter.js)
+(This is defined in src/util/IpadicFormatter.js)
 
-See also JSDoc under jsdoc directory.
+Also see the JSDoc under jsdoc directory.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can prepare tokenizer like this:
 
 ### Browser
 
-Only you need dist/browser/kuromoji.js, and dist/dict/*.dat.gz files
+You only need dist/browser/kuromoji.js, and dist/dict/*.dat.gz files
 
 Install by Bower package manager:
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can prepare tokenizer like this:
 
 ### Browser
 
-You only need dist/browser/kuromoji.js, and dist/dict/*.dat.gz files
+You only need the dist/browser/kuromoji.js and dist/dict/*.dat.gz files
 
 Install by Bower package manager:
 


### PR DESCRIPTION
Noticed a typo in the readme. See attached screenshot. 

<img width="945" alt="screen shot 2015-07-09 at 17 19 51" src="https://cloud.githubusercontent.com/assets/1316570/8609735/392b2ee8-265e-11e5-9f96-676238275523.png">
