### PR TITLE
improve error handling of DictionaryLoader

### DIFF
--- a/src/loader/DictionaryLoader.js
+++ b/src/loader/DictionaryLoader.js
@@ -69,15 +69,21 @@ DictionaryLoader.prototype.load = function (load_callback) {
     var dic = this.dic;
     var dic_path = this.dic_path;
     var loadArrayBuffer = this.loadArrayBuffer;
-
+    
     async.parallel([
         // Trie
         function (callback) {
             async.map([ "base.dat.gz", "check.dat.gz" ], function (filename, _callback) {
                 loadArrayBuffer(dic_path + filename, function (err, buffer) {
+                    if(err) {
+                        return _callback(err);
+                    }
                     _callback(null, buffer);
                 });
             }, function (err, buffers) {
+                if(err) {
+                    return callback(err);
+                }
                 var base_buffer = new Int32Array(buffers[0]);
                 var check_buffer = new Int32Array(buffers[1]);
 
@@ -89,9 +95,15 @@ DictionaryLoader.prototype.load = function (load_callback) {
         function (callback) {
             async.map([ "tid.dat.gz", "tid_pos.dat.gz", "tid_map.dat.gz" ], function (filename, _callback) {
                 loadArrayBuffer(dic_path + filename, function (err, buffer) {
+                    if(err) {
+                        return _callback(err);
+                    }
                     _callback(null, buffer);
                 });
             }, function (err, buffers) {
+                if(err) {
+                    return callback(err);
+                }
                 var token_info_buffer = new Uint8Array(buffers[0]);
                 var pos_buffer = new Uint8Array(buffers[1]);
                 var target_map_buffer = new Uint8Array(buffers[2]);
@@ -103,6 +115,9 @@ DictionaryLoader.prototype.load = function (load_callback) {
         // Connection cost matrix
         function (callback) {
             loadArrayBuffer(dic_path + "cc.dat.gz", function (err, buffer) {
+                if(err) {
+                    return callback(err);
+                }
                 var cc_buffer = new Int16Array(buffer);
                 dic.loadConnectionCosts(cc_buffer);
                 callback(null);
@@ -112,9 +127,15 @@ DictionaryLoader.prototype.load = function (load_callback) {
         function (callback) {
             async.map([ "unk.dat.gz", "unk_pos.dat.gz", "unk_map.dat.gz", "unk_char.dat.gz", "unk_compat.dat.gz", "unk_invoke.dat.gz" ], function (filename, _callback) {
                 loadArrayBuffer(dic_path + filename, function (err, buffer) {
+                    if(err) {
+                        return _callback(err);
+                    }
                     _callback(null, buffer);
                 });
             }, function (err, buffers) {
+                if(err) {
+                    return callback(err);
+                }
                 var unk_buffer = new Uint8Array(buffers[0]);
                 var unk_pos_buffer = new Uint8Array(buffers[1]);
                 var unk_map_buffer = new Uint8Array(buffers[2]);
@@ -203,7 +224,13 @@ NodeDictionaryLoader.prototype = Object.create(DictionaryLoader.prototype);
  */
 NodeDictionaryLoader.prototype.loadArrayBuffer = function (file, callback) {
     fs.readFile(file, function (err, buffer) {
+        if(err) {
+            return callback(err);
+        }
         node_zlib.gunzip(buffer, function (err2, decompressed) {
+            if(err2) {
+                return callback(err2);
+            }
             var typed_array = new Uint8Array(decompressed);
             callback(null, typed_array.buffer);
         });

--- a/src/loader/DictionaryLoader.js
+++ b/src/loader/DictionaryLoader.js
@@ -17,6 +17,7 @@
 
 "use strict";
 
+var path = require("path");
 var async = require("async");
 var zlib = require("zlibjs/bin/gunzip.min.js");
 
@@ -74,7 +75,7 @@ DictionaryLoader.prototype.load = function (load_callback) {
         // Trie
         function (callback) {
             async.map([ "base.dat.gz", "check.dat.gz" ], function (filename, _callback) {
-                loadArrayBuffer(dic_path + filename, function (err, buffer) {
+                loadArrayBuffer(path.join(dic_path, filename), function (err, buffer) {
                     if(err) {
                         return _callback(err);
                     }
@@ -94,7 +95,7 @@ DictionaryLoader.prototype.load = function (load_callback) {
         // Token info dictionaries
         function (callback) {
             async.map([ "tid.dat.gz", "tid_pos.dat.gz", "tid_map.dat.gz" ], function (filename, _callback) {
-                loadArrayBuffer(dic_path + filename, function (err, buffer) {
+                loadArrayBuffer(path.join(dic_path, filename), function (err, buffer) {
                     if(err) {
                         return _callback(err);
                     }
@@ -114,7 +115,7 @@ DictionaryLoader.prototype.load = function (load_callback) {
         },
         // Connection cost matrix
         function (callback) {
-            loadArrayBuffer(dic_path + "cc.dat.gz", function (err, buffer) {
+            loadArrayBuffer(path.join(dic_path, "cc.dat.gz"), function (err, buffer) {
                 if(err) {
                     return callback(err);
                 }
@@ -126,7 +127,7 @@ DictionaryLoader.prototype.load = function (load_callback) {
         // Unknown dictionaries
         function (callback) {
             async.map([ "unk.dat.gz", "unk_pos.dat.gz", "unk_map.dat.gz", "unk_char.dat.gz", "unk_compat.dat.gz", "unk_invoke.dat.gz" ], function (filename, _callback) {
-                loadArrayBuffer(dic_path + filename, function (err, buffer) {
+                loadArrayBuffer(path.join(dic_path, filename), function (err, buffer) {
                     if(err) {
                         return _callback(err);
                     }

--- a/test/loader/DictionaryLoaderTest.js
+++ b/test/loader/DictionaryLoaderTest.js
@@ -48,3 +48,13 @@ describe("DictionaryLoader", function () {
         expect(dictionaries.token_info_dictionary.getFeatures("0")).to.have.length.above(1);
     });
 });
+
+describe("DictionaryLoader couldn't load dictionary", function () {
+    it("should call with error", function (done) {
+        var loader = DictionaryLoader.getLoader("non-exist/dictionaries");
+        loader.load(function (err, dic) {
+            expect(err).to.be.an.instanceof(Error);
+            done();
+        });
+    });
+});

--- a/test/loader/DictionaryLoaderTest.js
+++ b/test/loader/DictionaryLoaderTest.js
@@ -51,6 +51,8 @@ describe("DictionaryLoader", function () {
 
 describe("DictionaryLoader about loading", function () {
     it("could load directory path without suffix /", function (done) {
+        this.timeout(5 * 60 * 1000); // 5 min
+        
         var loader = DictionaryLoader.getLoader("dist/dict");// not have suffix /
         loader.load(function (err, dic) {
             expect(err).to.be.null;

--- a/test/loader/DictionaryLoaderTest.js
+++ b/test/loader/DictionaryLoaderTest.js
@@ -49,8 +49,16 @@ describe("DictionaryLoader", function () {
     });
 });
 
-describe("DictionaryLoader couldn't load dictionary", function () {
-    it("should call with error", function (done) {
+describe("DictionaryLoader about loading", function () {
+    it("could load directory path without suffix /", function (done) {
+        var loader = DictionaryLoader.getLoader("dist/dict");// not have suffix /
+        loader.load(function (err, dic) {
+            expect(err).to.be.null;
+            expect(dic).to.not.be.undefined;
+            done();
+        });
+    });
+    it("couldn't load dictionary, then call with error", function (done) {
         var loader = DictionaryLoader.getLoader("non-exist/dictionaries");
         loader.load(function (err, dic) {
             expect(err).to.be.an.instanceof(Error);


### PR DESCRIPTION
This will improve error handling of DictionaryLoader.

Before:

- DictionaryLoader try to load **non**-exist dictionaries and wait for ∞.

After:

- DictionaryLoader try to load **non**-exist dictionaries and call callback with `Error`.
- Use `path.join` for joining dic_dir and filename.
      - https://nodejs.org/api/path.html#path_path_join_path1_path2