### PR TITLE
Fix resolution on Atom editor

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,10 +43,13 @@ gulp.task("build", function () {
         .pipe(sourcemaps.write())
         .pipe(gulp.dest("./dist/node/"));
 
-    browserify({
-        entries: [ "./src/kuromoji.js" ],
-        standalone : "kuromoji"
-    }).bundle()
+    var b = browserify({
+        entries: ["./src/kuromoji.js"],
+        standalone: "kuromoji" // window.kuromoji
+    });
+    // replace NodeDictionaryLoader to BrowserDictionaryLoader
+    b.require(__dirname + "/src/loader/BrowserDictionaryLoader.js", {expose: "./loader/NodeDictionaryLoader.js"});
+    b.bundle()
         .pipe(source("kuromoji.js"))
         .pipe(gulp.dest("./dist/browser/"));
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,8 +43,10 @@ gulp.task("build", function () {
         .pipe(sourcemaps.write())
         .pipe(gulp.dest("./dist/node/"));
 
-    browserify({ entries: [ "./src/kuromoji.js" ] })
-        .bundle()
+    browserify({
+        entries: [ "./src/kuromoji.js" ],
+        standalone : "kuromoji"
+    }).bundle()
         .pipe(source("kuromoji.js"))
         .pipe(gulp.dest("./dist/browser/"));
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "author": "Takuya Asano <takuya.a@gmail.com>",
   "description": "JavaScript implementation of Japanese morphological analyzer",
   "main": "./dist/node/kuromoji.js",
+  "browser": {
+    "./dist/node/loader/NodeDictionaryLoader.js": "./dist/node/loader/BrowserDictionaryLoader.js"
+  },
   "keywords": [
     "morphological analyzer",
     "tokenizer",

--- a/src/TokenizerBuilder.js
+++ b/src/TokenizerBuilder.js
@@ -18,7 +18,7 @@
 "use strict";
 
 var Tokenizer = require("./Tokenizer.js");
-var DictionaryLoader = require("./loader/DictionaryLoader.js");
+var DictionaryLoader = require("./loader/NodeDictionaryLoader.js");
 
 
 /**
@@ -40,7 +40,7 @@ function TokenizerBuilder(option) {
  * @param {TokenizerBuilder~onLoad} callback Callback function
  */
 TokenizerBuilder.prototype.build = function (callback) {
-    var loader = DictionaryLoader.getLoader(this.dic_path);
+    var loader = new DictionaryLoader(this.dic_path);
     loader.load(function (err, dic) {
         callback(err, new Tokenizer(dic));
     });

--- a/src/kuromoji.js
+++ b/src/kuromoji.js
@@ -31,10 +31,4 @@ var kuromoji = {
     }
 };
 
-if (typeof window === "undefined") {
-    // In node
-    module.exports = kuromoji;
-} else {
-    // In browser
-    window.kuromoji = kuromoji;
-}
+module.exports = kuromoji;

--- a/src/loader/BrowserDictionaryLoader.js
+++ b/src/loader/BrowserDictionaryLoader.js
@@ -1,0 +1,46 @@
+var zlib = require("zlibjs/bin/gunzip.min.js");
+var DictionaryLoader = require("./DictionaryLoader");
+/**
+ * BrowserDictionaryLoader inherits DictionaryLoader, using jQuery XHR for download
+ * @param {string} dic_path Dictionary path
+ * @constructor
+ */
+function BrowserDictionaryLoader(dic_path) {
+    DictionaryLoader.apply(this, [dic_path]);
+}
+BrowserDictionaryLoader.prototype = Object.create(DictionaryLoader.prototype);
+// BrowserDictionaryLoader.prototype.constructor = BrowserDictionaryLoader;
+
+/**
+ * Utility function to load gzipped dictionary
+ * @param {string} url Dictionary URL
+ * @param {BrowserDictionaryLoader~onLoad} callback Callback function
+ */
+BrowserDictionaryLoader.prototype.loadArrayBuffer = function (url, callback) {
+    var xhr = new XMLHttpRequest();
+    xhr.open("GET", url, true);
+    xhr.responseType = "arraybuffer";
+    xhr.onload = function () {
+        if (this.status !== 200) {
+            callback(xhr.statusText, null);
+        }
+        var arraybuffer = this.response;
+
+        var gz = new zlib.Zlib.Gunzip(new Uint8Array(arraybuffer));
+        var typed_array = gz.decompress();
+        callback(null, typed_array.buffer);
+    };
+    xhr.onerror = function (err) {
+        callback(err, null);
+    };
+    xhr.send();
+};
+
+/**
+ * Callback
+ * @callback BrowserDictionaryLoader~onLoad
+ * @param {Object} err Error object
+ * @param {Uint8Array} buffer Loaded buffer
+ */
+
+module.exports = BrowserDictionaryLoader;

--- a/src/loader/NodeDictionaryLoader.js
+++ b/src/loader/NodeDictionaryLoader.js
@@ -1,0 +1,40 @@
+var fs = require("fs");
+var node_zlib = require("zlib");
+var DictionaryLoader = require("./DictionaryLoader");
+/**
+ * NodeDictionaryLoader inherits DictionaryLoader
+ * @param {string} dic_path Dictionary path
+ * @constructor
+ */
+function NodeDictionaryLoader(dic_path) {
+    DictionaryLoader.apply(this, [ dic_path ]);
+}
+NodeDictionaryLoader.prototype = Object.create(DictionaryLoader.prototype);
+// NodeDictionaryLoader.prototype.constructor = NodeDictionaryLoader;
+
+/**
+ * Utility function
+ * @param {string} file Dictionary file path
+ * @param {NodeDictionaryLoader~onLoad} callback Callback function
+ */
+NodeDictionaryLoader.prototype.loadArrayBuffer = function (file, callback) {
+    fs.readFile(file, function (err, buffer) {
+        if(err) {
+            return callback(err);
+        }
+        node_zlib.gunzip(buffer, function (err2, decompressed) {
+            if(err2) {
+                return callback(err2);
+            }
+            var typed_array = new Uint8Array(decompressed);
+            callback(null, typed_array.buffer);
+        });
+    });
+};
+
+/**
+ * @callback NodeDictionaryLoader~onLoad
+ * @param {Object} err Error object
+ * @param {Uint8Array} buffer Loaded buffer
+ */
+module.exports = NodeDictionaryLoader;

--- a/test/loader/DictionaryLoaderTest.js
+++ b/test/loader/DictionaryLoaderTest.js
@@ -16,7 +16,7 @@
  */
 
 var expect = require("chai").expect;
-var DictionaryLoader = require("../../src/loader/DictionaryLoader.js");
+var DictionaryLoader = require("../../src/loader/NodeDictionaryLoader");
 
 var DIC_DIR = "dist/dict/";
 
@@ -28,7 +28,7 @@ describe("DictionaryLoader", function () {
     before(function (done) {
         this.timeout(5 * 60 * 1000); // 5 min
 
-        var loader = DictionaryLoader.getLoader(DIC_DIR);
+        var loader = new DictionaryLoader(DIC_DIR);
         loader.load(function (err, dic) {
             dictionaries = dic;
             done();
@@ -53,7 +53,7 @@ describe("DictionaryLoader about loading", function () {
     it("could load directory path without suffix /", function (done) {
         this.timeout(5 * 60 * 1000); // 5 min
         
-        var loader = DictionaryLoader.getLoader("dist/dict");// not have suffix /
+        var loader = new DictionaryLoader("dist/dict");// not have suffix /
         loader.load(function (err, dic) {
             expect(err).to.be.null;
             expect(dic).to.not.be.undefined;
@@ -61,7 +61,7 @@ describe("DictionaryLoader about loading", function () {
         });
     });
     it("couldn't load dictionary, then call with error", function (done) {
-        var loader = DictionaryLoader.getLoader("non-exist/dictionaries");
+        var loader = new DictionaryLoader("non-exist/dictionaries");
         loader.load(function (err, dic) {
             expect(err).to.be.an.instanceof(Error);
             done();

--- a/test/viterbi/ViterbiBuilderTest.js
+++ b/test/viterbi/ViterbiBuilderTest.js
@@ -16,7 +16,7 @@
  */
 
 var expect = require("chai").expect;
-var DictionaryLoader = require("../../src/loader/DictionaryLoader.js");
+var DictionaryLoader = require("../../src/loader/NodeDictionaryLoader.js");
 var ViterbiBuilder = require("../../src/viterbi/ViterbiBuilder.js");
 
 var DIC_DIR = "dist/dict/";
@@ -28,7 +28,7 @@ describe("ViterbiBuilder", function () {
 
     before(function (done) {
         this.timeout(5 * 60 * 1000); // 5 min
-        var loader = DictionaryLoader.getLoader(DIC_DIR);
+        var loader = new DictionaryLoader(DIC_DIR);
         loader.load(function (err, dic) {
             viterbi_builder = new ViterbiBuilder(dic);
             done();


### PR DESCRIPTION
@takuyaa Hi, I fixed `require("kuromoji"); // undefeined` issue on some env like Atom.

## Purpose

Currently, `kuromoji.js` doesn't work on Atom editor(plugin).
This pull request fix this issue.

`require("kuromoji"); // undefeined` in Atom.

## Changes

- Remove `window` detection from `src/kuromoji.js` and `DictionaryLoader`
- Split up `DictionaryLoader` into `BrowserDictionaryLoader` and `NodeDictionaryLoader`

Atom has `window` object... it means that `module.exports = undefined` @ `src/kuromoji.js`

I refactor this feature detection and move feature detection to browserify's build phase.
(So, feature detection code was removed)

- `src/` code use directly `NodeDictionaryLoader`.
- `dist/browser/kuromoji.js` use directly `BrowserDictionaryLoader` ( `dist/browser/kuromoji.js` doesn't contain `NodeDictionaryLoader`)

I'v added a macro that replace `NodeDictionaryLoader` to `BrowserDictionaryLoader` into `gulpfile.js` and `package.json`