### PR TITLE
Support loading dictionaries from the filesystem in the browser

### DIFF
--- a/src/loader/BrowserDictionaryLoader.js
+++ b/src/loader/BrowserDictionaryLoader.js
@@ -41,8 +41,9 @@ BrowserDictionaryLoader.prototype.loadArrayBuffer = function (url, callback) {
     xhr.open("GET", url, true);
     xhr.responseType = "arraybuffer";
     xhr.onload = function () {
-        if (this.status !== 200) {
+        if (this.status > 0 && this.status !== 200) {
             callback(xhr.statusText, null);
+            return;
         }
         var arraybuffer = this.response;
 


### PR DESCRIPTION
This PR fixes two bugs:
1. When the `loadArrayBuffer` XHR fails, it applies its callback to the error but fails to return, which results in a later `async` error related to calling a callback more than once. This avoids calling the `loadArrayBuffer` callback twice by returning after applying the callback to an error.
2. It's not currently possible to use this library in a web page served from the filesystem due to a different bug. The problem is that the status of filesystem XHRs is always 0 because status is an HTTP-specific concept. This works around the problem by adding an extra `this.status > 0` conjunct to the XHR error test.
