### PR TITLE
Fix decoding bug of short int

### DIFF
--- a/src/util/ByteBuffer.js
+++ b/src/util/ByteBuffer.js
@@ -211,7 +211,11 @@ ByteBuffer.prototype.getShort = function (index) {
     }
     var lower = this.buffer[index];
     var upper = this.buffer[index + 1];
-    return (upper << 8) + lower;
+    var value = (upper << 8) + lower;
+    if (value & 0x8000) {
+	value = -((value - 1) ^ 0xFFFF);
+    }
+    return value
 };
 
 // Write integer to buffer by little endian

--- a/test/util/ByteBuffer.js
+++ b/test/util/ByteBuffer.js
@@ -25,6 +25,14 @@ describe("ByteBuffer static methods", function () {
         byteBuffer = new ByteBuffer(50);
     });
 
+    it("putShort() and getShort()", function () {
+        var v = -413;
+        byteBuffer.putShort(v);
+        expect(byteBuffer.position).equals(2);
+        var got = byteBuffer.getShort(0);
+        expect(got).equals(v);
+    });
+
     it("putString() and getString() 2 bytes UTF-8", function () {
         var str = "âbcde";
         byteBuffer.putString(str);


### PR DESCRIPTION
This bug caused excessive evaluation of negative word_cost. (e.g. 研究=-413 is overvalued 65123.)
See https://github.com/takuyaa/kuromoji.js/issues/23