### PR TITLE
Update vue dependency in demo

### DIFF
--- a/demo/bower.json
+++ b/demo/bower.json
@@ -16,6 +16,6 @@
   ],
   "dependencies": {
     "foundation": "~5.4.7",
-    "vue": "~0.10.6"
+    "vue": "^2.5.16"
   }
 }

--- a/demo/tokenize.html
+++ b/demo/tokenize.html
@@ -91,7 +91,7 @@
                         </tr>
                         </thead>
                         <tbody>
-                        <tr v-repeat="token: tokens">
+                        <tr v-for="token in tokens">
                             <td>{{token.surface_form}}</td>
                             <td>{{token.pos}}</td>
                             <td>{{token.pos_detail_1}}</td>
@@ -110,7 +110,7 @@
                     <a href="#" v-on="click: drawGraph" v-show="svgStyle=='hidden'" class="radius button">ラティスを表示する</a>
                     -->
 
-                    <svg v-style="visibility: svgStyle" width="100%" height="800px">
+                    <svg v-bind:style="{ visibility: svgStyle }" width="100%" height="800px">
                         <g id="lattice" transform="translate(20,20)"></g>
                     </svg>
 


### PR DESCRIPTION
Updated the vue dependency for the demo.

The old version of vue wouldn't update `v-model` on Japanese IME input, causing the demo to be buggy (on chrome/osx anyway)