### PR TITLE
Allow no option for TokenizerBuilder

### DIFF
--- a/src/TokenizerBuilder.js
+++ b/src/TokenizerBuilder.js
@@ -27,7 +27,7 @@ var DictionaryLoader = require("./loader/NodeDictionaryLoader");
  * @constructor
  */
 function TokenizerBuilder(option) {
-    if (option.dicPath == null) {
+    if (!option || option.dicPath == null) {
         this.dic_path = "dict/";
     } else {
         this.dic_path = option.dicPath;


### PR DESCRIPTION
In the current version, an option object without dicPath can be passed into the TokenizerBuilder. If so, it will use a default dicPath. However, not passing option is not possible, even though this field is the only prop on option.