### PR TITLE
Fix/Wrap GZ File Decompression in Try-Catch Block

### DIFF
--- a/src/loader/BrowserDictionaryLoader.js
+++ b/src/loader/BrowserDictionaryLoader.js
@@ -47,8 +47,14 @@ BrowserDictionaryLoader.prototype.loadArrayBuffer = function (url, callback) {
         }
         var arraybuffer = this.response;
 
-        var gz = new zlib.Zlib.Gunzip(new Uint8Array(arraybuffer));
-        var typed_array = gz.decompress();
+        try {
+            var gz = new zlib.Zlib.Gunzip(new Uint8Array(arraybuffer));
+            var typed_array = gz.decompress();
+        } catch (error) {
+            console.log("Error while decompressing .gz file. Skipping decompression step as file may have been auto-decompressed by browser.")
+            typed_array = arraybuffer;
+        }
+        
         callback(null, typed_array.buffer);
     };
     xhr.onerror = function (err) {


### PR DESCRIPTION
- During fetching of the dict.gz files, explicit decompression of .gz files takes place. 
- However, some browsers will perform auto-decompression of these files upon retrieval, thus this explicit step results in an error.
- Wrapping this step in a try catch block helps to bypass and skip this decompression step, should it be decompressed by the browser already.